### PR TITLE
Add --raw flag for transferring encrypted datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Source options:
 - --minimumtimetokeepsnapshotsonsource (string): Minimum time how long snapshots should exist on the source. With this set snapshots on the source will be kept at least that long even if there are more than the number of snapshots given in the --snapshotstokeeponsource option. (Eg: *1week*, *1month* or something like that).
 - --replicate (flag):						Only needed for the very first backup. It will replicate all snapshots from the source to the destination.
 - --recursive (flag):						Should we backup all decendent datasets on the source to the destination.
+- --raw (flag):		          		Backup the data in raw mode, this sends the encrypted version of a dataset, if using ZFS encryption
 - --datasetstoignoreonsource (string):		If you are recursivly backing up, you can disable backing up datasets that match this comma seperated list of datasets.
 
 Destination snapshots:

--- a/zfstimemachinebackup.perl
+++ b/zfstimemachinebackup.perl
@@ -41,6 +41,7 @@ my %commandlineoption = JNX::Configuration::newFromDefaults( {
 																	'createsnapshotonsource'				=>	[0,'flag'],
 																	'snapshotstokeeponsource'				=>	[0,'number'],
 																	'minimumtimetokeepsnapshotsonsource'	=>	['','string'],
+																	'raw'								=>  [0,'flag'],
 																	'replicate'								=>	[0,'flag'],
 																	'deduplicate'							=>	[0,'flag'],
 																	'deletesnapshotsondestination'			=>	[1,'flag'],
@@ -233,11 +234,11 @@ DATASET:for my $sourcedataset (@sourcedatasets)
 			
 			if( $lastcommonsnapshot )
 			{
-				$zfssendcommand	= 'zfs send '.($commandlineoption{verbose}?'-v ':undef).($commandlineoption{deduplicate}?'-D ':undef).'-I "'.$sourcedataset.'@'.$lastcommonsnapshot.'" "'.$sourcedataset.'@'.$snapshotdate.'"';
+				$zfssendcommand	= 'zfs send '.($commandlineoption{verbose}?'-v ':undef).($commandlineoption{raw}?'-w ':undef).($commandlineoption{deduplicate}?'-D ':undef).'-I "'.$sourcedataset.'@'.$lastcommonsnapshot.'" "'.$sourcedataset.'@'.$snapshotdate.'"';
 			}
 			else
 			{
-				$zfssendcommand	= 'zfs send '.($commandlineoption{verbose}?'-v ':undef).($commandlineoption{replicate}?'-R ':undef).($commandlineoption{deduplicate}?'-D ':undef).'"'.$sourcedataset.'@'.$snapshotdate.'"';
+				$zfssendcommand	= 'zfs send '.($commandlineoption{verbose}?'-v ':undef).($commandlineoption{raw}?'-w ':undef).($commandlineoption{replicate}?'-R ':undef).($commandlineoption{deduplicate}?'-D ':undef).'"'.$sourcedataset.'@'.$snapshotdate.'"';
 			}
 
 


### PR DESCRIPTION
When backing up encrypted datasets, it is convenient to not have to
trust the destination.