### PR TITLE
Default to using control sockets for SSH persisting 15 minutes

### DIFF
--- a/zfstimemachinebackup.perl
+++ b/zfstimemachinebackup.perl
@@ -29,12 +29,12 @@ use JNX::Configuration;
 
 my %commandlineoption = JNX::Configuration::newFromDefaults( {																	
 																	'sourcehost'							=>	['','string'],
-																	'sourcehostoptions'						=>	['-C -l root','string'],
+																	'sourcehostoptions'						=>	['-C -l root -o ControlMaster=auto -o ControlPath=/tmp/%r@%h:%p -o ControlPersist=15m','string'],
 																	'sourcedataset'							=>	['','string'],
 																	'sourceenvironment'                     =>  ['','string'],
 
 																	'destinationhost'						=>	['','string'],
-																	'destinationhostoptions'				=>	['-C -l root','string'],
+																	'destinationhostoptions'				=>	['-C -l root -o ControlMaster=auto -o ControlPath=/tmp/%r@%h:%p -o ControlPersist=15m','string'],
 																	'destinationdataset'					=>	['','string'],
 																	'destinationenvironment'                =>  ['"PATH=\$PATH:/usr/local/bin"','string'],
 


### PR DESCRIPTION
This then requires only one auth for SSH each backup.  This is
convenient if you auth with a password or some key that isn't in root's
ssh-agent.

If you backup more often than the default ControlPersist (say, in a loop
every 10 minutes), you can auth once you start you internet connection
and then it will reuse it for every subsequent backup.

This is supported since 2004 on the client side for OpenSSH.